### PR TITLE
Fix slow type-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+*.tsbuildinfo

--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,11 +1,15 @@
-import { useExists, useTypedFile } from '@artifact/client/hooks'
+import { useExists, useJson } from '@artifact/client/hooks'
 import { accountDataSchema, type AccountData } from '../types/account.ts'
 import { useEffect, useMemo, useState } from 'react'
 import equals from 'fast-deep-equal'
 
 const useAccountData = () => {
   const exists = useExists('profile.json')
-  const typedData = useTypedFile('profile.json', accountDataSchema)
+  const raw = useJson('profile.json')
+  const typedData = useMemo(() => {
+    if (raw === undefined) return undefined
+    return accountDataSchema.parse(raw)
+  }, [raw])
   const [data, setData] = useState<AccountData>()
 
   useEffect(() => {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,71 +1,30 @@
 import { z } from 'zod'
 
-export type UserProfile = {
-  name: string
-  email: string
-  profilePicture: string
-}
-
-export type PaymentMethod = {
-  id: string
-  type: string
-  name: string
-  value: string
-  isConnected: boolean
-}
-
-export type StorageUsage = {
-  gained: number
-  lost: number
-  gainedCost: number
-  lostRefund: number
-}
-
-export type UsageRecord = {
-  period: string
-  storage: StorageUsage
-  compute: number
-  computeCost: number
-  bandwidth: number
-  bandwidthCost: number
-  aiTokens: number
-  aiTokensCost: number
-}
-
-export type BillingData = {
-  balance: number
-  currency: string
-  usageHistory: UsageRecord[]
-}
-
-export type AccountData = {
-  user: UserProfile
-  paymentMethods: PaymentMethod[]
-  billing: BillingData
-}
-
-const userProfileSchema: z.ZodType<UserProfile> = z.object({
+export const userProfileSchema = z.object({
   name: z.string(),
   email: z.string().email(),
   profilePicture: z.string()
 })
+export type UserProfile = z.infer<typeof userProfileSchema>
 
-const paymentMethodSchema: z.ZodType<PaymentMethod> = z.object({
+export const paymentMethodSchema = z.object({
   id: z.string(),
   type: z.string(),
   name: z.string(),
   value: z.string(),
   isConnected: z.boolean()
 })
+export type PaymentMethod = z.infer<typeof paymentMethodSchema>
 
-const storageUsageSchema: z.ZodType<StorageUsage> = z.object({
+export const storageUsageSchema = z.object({
   gained: z.number(),
   lost: z.number(),
   gainedCost: z.number(),
   lostRefund: z.number()
 })
+export type StorageUsage = z.infer<typeof storageUsageSchema>
 
-const usageRecordSchema: z.ZodType<UsageRecord> = z.object({
+export const usageRecordSchema = z.object({
   period: z.string(),
   storage: storageUsageSchema,
   compute: z.number(),
@@ -75,18 +34,22 @@ const usageRecordSchema: z.ZodType<UsageRecord> = z.object({
   aiTokens: z.number(),
   aiTokensCost: z.number()
 })
+export type UsageRecord = z.infer<typeof usageRecordSchema>
 
-const billingDataSchema: z.ZodType<BillingData> = z.object({
+export const billingDataSchema = z.object({
   balance: z.number(),
   currency: z.string(),
   usageHistory: z.array(usageRecordSchema)
 })
+export type BillingData = z.infer<typeof billingDataSchema>
 
-export const accountDataSchema: z.ZodType<AccountData> = z.object({
+export const accountDataSchema = z.object({
   user: userProfileSchema,
   paymentMethods: z.array(paymentMethodSchema),
   billing: billingDataSchema
 })
+
+export type AccountData = z.infer<typeof accountDataSchema>
 
 // Example account object shape
 // const AccountData: {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -12,6 +12,8 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": "tsconfig.app.tsbuildinfo",
     "jsx": "react-jsx",
 
     /* Linting */

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,8 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": "tsconfig.node.tsbuildinfo",
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
## Summary
- avoid deep type instantiation by parsing JSON manually
- define types directly from `zod` schemas
- cache TypeScript builds with incremental compilation
- ignore build info files

## Testing
- `npm run type-check`
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_684389c28050832b96fbbc5af6151108