### PR TITLE
Refactor payment modal handling

### DIFF
--- a/src/AccountView.tsx
+++ b/src/AccountView.tsx
@@ -9,7 +9,6 @@ import {
 } from './components/index.ts'
 import InitializingModal from './components/modals/InitializingModal.tsx'
 import DeleteAccountModal from './components/modals/DeleteAccountModal.tsx'
-import AddPaymentModal from './components/modals/AddPaymentModal.tsx'
 import TopUpModal from './components/modals/TopUpModal.tsx'
 import useAccountData from './hooks/useAccountData.ts'
 import useAccountSaver from './hooks/useAccountSaver.ts'
@@ -49,9 +48,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
   })
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([])
-  const [showAddPaymentModal, setShowAddPaymentModal] = useState(false)
-  const [newPaymentType, setNewPaymentType] = useState('ethereum')
-  const [newPaymentValue, setNewPaymentValue] = useState('')
 
   // Billing related state
   const [billingData, setBillingData] = useState<BillingData>({
@@ -101,50 +97,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
       paymentMethods,
       billing: billingData
     })
-  }
-
-  const togglePaymentConnection = (id: string) => {
-    setPaymentMethods((methods) =>
-      methods.map((method) =>
-        method.id === id
-          ? { ...method, isConnected: !method.isConnected }
-          : method
-      )
-    )
-  }
-
-  const handleAddPayment = () => {
-    if (!newPaymentValue.trim()) return
-
-    const newPayment = {
-      id: `${newPaymentType}${Date.now()}`,
-      type: newPaymentType,
-      name:
-        newPaymentType === 'ethereum'
-          ? 'Ethereum Wallet'
-          : newPaymentType === 'wise'
-            ? 'Wise Account'
-            : 'Bank Account',
-      value: newPaymentValue,
-      isConnected: true
-    }
-
-    setPaymentMethods([...paymentMethods, newPayment])
-    setNewPaymentValue('')
-    setShowAddPaymentModal(false)
-  }
-
-  const navigateToWalletNapp = () => {
-    // Select home repository
-    // selectHomeRepository()
-    // Navigate to the napps view
-    // setCurrentView('napps')
-    // // Create a navigation marker
-    // navigateTo({
-    //   title: 'Wallet Manager',
-    //   icon: 'Package',
-    //   view: 'napps'
-    // })
   }
 
   const handleTopUp = () => {
@@ -245,9 +197,7 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
 
       <PaymentSection
         paymentMethods={paymentMethods}
-        togglePaymentConnection={togglePaymentConnection}
-        setShowAddPaymentModal={setShowAddPaymentModal}
-        navigateToWalletNapp={navigateToWalletNapp}
+        setPaymentMethods={setPaymentMethods}
         skeleton={isSkeleton}
       />
 
@@ -275,16 +225,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
           <DeleteAccountModal
             showDeleteConfirm={showDeleteConfirm}
             dismissDeleteConfirm={dismissDeleteConfirm}
-          />
-
-          <AddPaymentModal
-            showAddPaymentModal={showAddPaymentModal}
-            setShowAddPaymentModal={setShowAddPaymentModal}
-            newPaymentType={newPaymentType}
-            setNewPaymentType={setNewPaymentType}
-            newPaymentValue={newPaymentValue}
-            setNewPaymentValue={setNewPaymentValue}
-            handleAddPayment={handleAddPayment}
           />
 
           <TopUpModal

--- a/src/components/PaymentSection.tsx
+++ b/src/components/PaymentSection.tsx
@@ -1,23 +1,21 @@
-import React from 'react'
-import { Wallet, CreditCard, Landmark, ExternalLink, Plus } from 'lucide-react'
+import React, { useState } from 'react'
+import { Wallet, CreditCard, Landmark, Plus } from 'lucide-react'
+import AddPaymentModal from './modals/AddPaymentModal.tsx'
 
 import type { PaymentMethod } from '../types/account.ts'
 
 interface PaymentSectionProps {
-  paymentMethods?: PaymentMethod[]
-  togglePaymentConnection?: (id: string) => void
-  setShowAddPaymentModal?: (show: boolean) => void
-  navigateToWalletNapp?: () => void
+  paymentMethods: PaymentMethod[]
+  setPaymentMethods: React.Dispatch<React.SetStateAction<PaymentMethod[]>>
   skeleton?: boolean
 }
 
 const PaymentSection: React.FC<PaymentSectionProps> = ({
   paymentMethods,
-  togglePaymentConnection,
-  setShowAddPaymentModal,
-  navigateToWalletNapp,
+  setPaymentMethods,
   skeleton
 }) => {
+  const [showAddPaymentModal, setShowAddPaymentModal] = useState(false)
   if (skeleton) {
     return (
       <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
@@ -43,67 +41,95 @@ const PaymentSection: React.FC<PaymentSectionProps> = ({
     }
   }
 
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6 transition-all duration-300 hover:shadow-md">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-medium">Payment Methods</h2>
-        <button
-          onClick={() => setShowAddPaymentModal!(true)}
-          className="px-3 py-1.5 bg-blue-500 text-white rounded flex items-center text-sm hover:bg-blue-600 transition-colors"
-        >
-          <Plus size={14} className="mr-1" />
-          Add Payment Method
-        </button>
-      </div>
+  const togglePaymentConnection = (id: string) => {
+    setPaymentMethods((methods) =>
+      methods.map((method) =>
+        method.id === id
+          ? { ...method, isConnected: !method.isConnected }
+          : method
+      )
+    )
+  }
 
-      {paymentMethods && paymentMethods.length > 0 ? (
-        <div className="space-y-4">
-          {paymentMethods.map((method) => (
-            <div
-              key={method.id}
-              className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
-            >
-              <div className="flex items-center justify-between flex-wrap gap-4">
-                <div className="flex items-center">
-                  {getPaymentIcon(method.type)}
-                  <div className="ml-4">
-                    <div className="font-medium">{method.name}</div>
-                    <div className="text-sm text-gray-600 font-mono">
-                      {method.value}
+  const handleAddPayment = (type: string, value: string) => {
+    const newPayment = {
+      id: `${type}${Date.now()}`,
+      type,
+      name:
+        type === 'ethereum'
+          ? 'Ethereum Wallet'
+          : type === 'wise'
+            ? 'Wise Account'
+            : 'Bank Account',
+      value,
+      isConnected: true
+    }
+
+    setPaymentMethods([...paymentMethods, newPayment])
+    setShowAddPaymentModal(false)
+  }
+
+  return (
+    <>
+      <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6 transition-all duration-300 hover:shadow-md">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-medium">Payment Methods</h2>
+          <button
+            onClick={() => setShowAddPaymentModal(true)}
+            className="px-3 py-1.5 bg-blue-500 text-white rounded flex items-center text-sm hover:bg-blue-600 transition-colors"
+          >
+            <Plus size={14} className="mr-1" />
+            Add Payment Method
+          </button>
+        </div>
+
+        {paymentMethods && paymentMethods.length > 0 ? (
+          <div className="space-y-4">
+            {paymentMethods.map((method) => (
+              <div
+                key={method.id}
+                className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                <div className="flex items-center justify-between flex-wrap gap-4">
+                  <div className="flex items-center">
+                    {getPaymentIcon(method.type)}
+                    <div className="ml-4">
+                      <div className="font-medium">{method.name}</div>
+                      <div className="text-sm text-gray-600 font-mono">
+                        {method.value}
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div className="flex items-center space-x-2">
-                  <button
-                    onClick={() => navigateToWalletNapp!()}
-                    className="p-2 text-blue-500 hover:text-blue-700 transition-colors flex items-center"
-                  >
-                    <ExternalLink size={16} className="mr-1" />
-                    <span className="text-sm">Open Wallet App</span>
-                  </button>
-                  <button
-                    onClick={() => togglePaymentConnection!(method.id)}
-                    className={`px-3 py-1.5 rounded text-sm transition-colors ${
-                      method.isConnected
-                        ? 'bg-red-50 text-red-600 hover:bg-red-100'
-                        : 'bg-green-50 text-green-600 hover:bg-green-100'
-                    }`}
-                  >
-                    {method.isConnected ? 'Disconnect' : 'Connect'}
-                  </button>
+                  <div className="flex items-center space-x-2">
+                    <button
+                      onClick={() => togglePaymentConnection(method.id)}
+                      className={`px-3 py-1.5 rounded text-sm transition-colors ${
+                        method.isConnected
+                          ? 'bg-red-50 text-red-600 hover:bg-red-100'
+                          : 'bg-green-50 text-green-600 hover:bg-green-100'
+                      }`}
+                    >
+                      {method.isConnected ? 'Disconnect' : 'Connect'}
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div className="text-center py-8 text-gray-500">
-          <Wallet size={32} className="mx-auto mb-2 text-gray-300" />
-          <p>No payment methods connected yet.</p>
-          <p className="text-sm">Add a payment method to get started.</p>
-        </div>
-      )}
-    </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8 text-gray-500">
+            <Wallet size={32} className="mx-auto mb-2 text-gray-300" />
+            <p>No payment methods connected yet.</p>
+            <p className="text-sm">Add a payment method to get started.</p>
+          </div>
+        )}
+      </div>
+      <AddPaymentModal
+        show={showAddPaymentModal}
+        onAdd={handleAddPayment}
+        onClose={() => setShowAddPaymentModal(false)}
+      />
+    </>
   )
 }
 

--- a/src/components/modals/AddPaymentModal.tsx
+++ b/src/components/modals/AddPaymentModal.tsx
@@ -1,26 +1,21 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { X } from 'lucide-react'
 
 interface AddPaymentModalProps {
-  showAddPaymentModal: boolean
-  setShowAddPaymentModal: (show: boolean) => void
-  newPaymentType: string
-  setNewPaymentType: (type: string) => void
-  newPaymentValue: string
-  setNewPaymentValue: (value: string) => void
-  handleAddPayment: () => void
+  show: boolean
+  onAdd: (type: string, value: string) => void
+  onClose: () => void
 }
 
 const AddPaymentModal: React.FC<AddPaymentModalProps> = ({
-  showAddPaymentModal,
-  setShowAddPaymentModal,
-  newPaymentType,
-  setNewPaymentType,
-  newPaymentValue,
-  setNewPaymentValue,
-  handleAddPayment
+  show,
+  onAdd,
+  onClose
 }) => {
-  if (!showAddPaymentModal) return null
+  const [paymentType, setPaymentType] = useState('ethereum')
+  const [paymentValue, setPaymentValue] = useState('')
+
+  if (!show) return null
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 animate-fadeIn">
@@ -28,7 +23,7 @@ const AddPaymentModal: React.FC<AddPaymentModalProps> = ({
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-medium">Add Payment Method</h3>
           <button
-            onClick={() => setShowAddPaymentModal(false)}
+            onClick={onClose}
             className="text-gray-500 hover:text-gray-700 transition-colors"
           >
             <X size={20} />
@@ -41,8 +36,8 @@ const AddPaymentModal: React.FC<AddPaymentModalProps> = ({
               Payment Type
             </label>
             <select
-              value={newPaymentType}
-              onChange={(e) => setNewPaymentType(e.target.value)}
+              value={paymentType}
+              onChange={(e) => setPaymentType(e.target.value)}
               className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               <option value="ethereum">Ethereum Wallet</option>
@@ -53,20 +48,20 @@ const AddPaymentModal: React.FC<AddPaymentModalProps> = ({
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              {newPaymentType === 'ethereum'
+              {paymentType === 'ethereum'
                 ? 'Ethereum Address'
-                : newPaymentType === 'wise'
+                : paymentType === 'wise'
                   ? 'Wise Email'
                   : 'Account Number'}
             </label>
             <input
               type="text"
-              value={newPaymentValue}
-              onChange={(e) => setNewPaymentValue(e.target.value)}
+              value={paymentValue}
+              onChange={(e) => setPaymentValue(e.target.value)}
               placeholder={
-                newPaymentType === 'ethereum'
+                paymentType === 'ethereum'
                   ? '0x...'
-                  : newPaymentType === 'wise'
+                  : paymentType === 'wise'
                     ? 'email@example.com'
                     : 'XXXX-XXXX-XXXX-XXXX'
               }
@@ -76,14 +71,18 @@ const AddPaymentModal: React.FC<AddPaymentModalProps> = ({
 
           <div className="flex justify-end space-x-3 pt-4">
             <button
-              onClick={() => setShowAddPaymentModal(false)}
+              onClick={onClose}
               className="px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
             >
               Cancel
             </button>
             <button
-              onClick={handleAddPayment}
-              disabled={!newPaymentValue.trim()}
+              onClick={() => {
+                onAdd(paymentType, paymentValue)
+                setPaymentValue('')
+                setPaymentType('ethereum')
+              }}
+              disabled={!paymentValue.trim()}
               className="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 disabled:opacity-50 transition-colors"
             >
               Add Payment Method


### PR DESCRIPTION
## Summary
- internalize AddPaymentModal state
- manage payment actions inside PaymentSection
- slim down AccountView props for PaymentSection

## Testing
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_6843947a28c4832b967be8757e0b71fb