### PR TITLE
Fix profile picture handling

### DIFF
--- a/src/components/ProfileSection.tsx
+++ b/src/components/ProfileSection.tsx
@@ -3,6 +3,7 @@ import { useArtifact } from '@artifact/client/hooks'
 import { User, Camera, Edit, CheckCircle, X } from 'lucide-react'
 
 import type { UserProfile } from '../types/account.ts'
+import useFileUrl from '../hooks/useFileUrl.ts'
 
 interface ProfileProps {
   userProfile?: UserProfile
@@ -19,6 +20,7 @@ const ProfileSection: React.FC<ProfileProps> = ({
 }) => {
   const artifact = useArtifact()
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const pictureUrl = useFileUrl(userProfile?.profilePicture)
 
   const [editingName, setEditingName] = useState(false)
   const [tempName, setTempName] = useState(userProfile?.name ?? '')
@@ -86,9 +88,9 @@ const ProfileSection: React.FC<ProfileProps> = ({
       <div className="flex items-center space-x-6">
         <div className="relative">
           <div className="w-24 h-24 rounded-full bg-gray-200 flex items-center justify-center overflow-hidden transition-all duration-300 hover:bg-gray-300">
-            {userProfile!.profilePicture ? (
+            {pictureUrl ? (
               <img
-                src={userProfile!.profilePicture}
+                src={pictureUrl}
                 alt="Profile"
                 className="w-full h-full object-cover"
               />

--- a/src/hooks/useFileUrl.ts
+++ b/src/hooks/useFileUrl.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { useFile } from '@artifact/client/hooks'
+
+/**
+ * Returns an object URL for a file stored in the Artifact. If the path is an
+ * http(s) or data URL it is returned as-is.
+ */
+export default function useFileUrl(path?: string): string | undefined {
+  const isRemote = !!path && /^(?:https?|data):/.test(path)
+  const data = useFile(!path || isRemote ? '' : path)
+  const [url, setUrl] = useState<string>()
+
+  useEffect(() => {
+    if (!path) {
+      setUrl(undefined)
+      return
+    }
+    if (isRemote) {
+      setUrl(path)
+      return
+    }
+    if (!data) {
+      setUrl(undefined)
+      return
+    }
+    const blob = new Blob([data])
+    const obj = URL.createObjectURL(blob)
+    setUrl(obj)
+    return () => URL.revokeObjectURL(obj)
+  }, [path, isRemote, data])
+
+  return url
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ const mockProfile: AccountData = {
   user: {
     name: 'Jane Doe',
     email: 'jane@example.com',
-    profilePicture: 'https://example.com/avatar.jpg'
+    profilePicture: 'https://i.pravatar.cc/300'
   },
   paymentMethods: [
     {


### PR DESCRIPTION
## Summary
- handle artifact file URLs with a new `useFileUrl` hook
- show profile pictures using `useFileUrl`
- use a working placeholder image in the mock profile

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_684397495ab4832b896d95997c0c4c33