### PR TITLE
Fix placeholder to avoid early hook usage

### DIFF
--- a/src/AccountSkeleton.tsx
+++ b/src/AccountSkeleton.tsx
@@ -1,0 +1,47 @@
+/** Skeleton view shown while artifact context loads */
+export default function AccountSkeleton() {
+  return (
+    <div className="animate-fadeIn p-6">
+      <div className="h-8 w-40 bg-gray-200 rounded mb-6" />
+      <div className="space-y-6">
+        {/* Profile section skeleton */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+          <div className="h-5 w-40 bg-gray-200 rounded mb-4" />
+          <div className="flex items-center space-x-6">
+            <div className="w-24 h-24 bg-gray-200 rounded-full" />
+            <div className="flex-1 space-y-4">
+              <div className="h-4 w-3/4 bg-gray-200 rounded" />
+              <div className="h-4 w-1/2 bg-gray-200 rounded" />
+            </div>
+          </div>
+        </div>
+
+        {/* Payment section skeleton */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+          <div className="h-5 w-40 bg-gray-200 rounded mb-4" />
+          <div className="space-y-4">
+            <div className="h-10 bg-gray-200 rounded" />
+            <div className="h-10 bg-gray-200 rounded" />
+            <div className="h-10 bg-gray-200 rounded" />
+          </div>
+        </div>
+
+        {/* Billing section skeleton */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+          <div className="h-5 w-40 bg-gray-200 rounded mb-4" />
+          <div className="space-y-4">
+            <div className="h-8 bg-gray-200 rounded" />
+            <div className="h-32 bg-gray-200 rounded" />
+            <div className="h-8 bg-gray-200 rounded" />
+          </div>
+        </div>
+
+        {/* Security section skeleton */}
+        <div className="bg-white rounded-lg border border-gray-200 p-6">
+          <div className="h-5 w-40 bg-gray-200 rounded mb-4" />
+          <div className="h-10 bg-gray-200 rounded" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { ArtifactFrame, ArtifactSyncer } from '@artifact/client/react'
 import { HOST_SCOPE } from '@artifact/client/api'
 import App from './App.tsx'
+import AccountSkeleton from './AccountSkeleton.tsx'
 import type { AccountData } from './types/account'
 import './index.css'
 
@@ -31,13 +32,13 @@ const mockProfile: AccountData = {
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ArtifactFrame
-      placeholder={<App skeleton />}
+      placeholder={<AccountSkeleton />}
       mockRepos={{ mock: { main: { 'profile.json': mockProfile } } }}
       mockFrameProps={{
         target: { did: HOST_SCOPE.did, repo: 'mock', branch: 'main' }
       }}
     >
-      <ArtifactSyncer>
+      <ArtifactSyncer placeholder={<AccountSkeleton />}>
         <App />
       </ArtifactSyncer>
     </ArtifactFrame>


### PR DESCRIPTION
## Summary
- provide skeleton component that does not rely on Artifact context
- use AccountSkeleton as placeholder for `ArtifactFrame` and `ArtifactSyncer`

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6850fda657d0832b90c16b36f49bbc96