### PR TITLE
Fix type-check error

### DIFF
--- a/src/AccountView.tsx
+++ b/src/AccountView.tsx
@@ -71,7 +71,7 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
   }, [data])
 
   useEffect(() => {
-    if (!initialized && error?.message === 'profile.json not found') {
+    if (!initialized && error === 'profile.json not found') {
       setInitializing(true)
       setInitialized(true)
       const defaultAccount = {
@@ -184,7 +184,7 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
       </h1>
       {error && (
         <p className="mb-4 text-red-600" role="alert">
-          {error.message}
+          {error}
         </p>
       )}
 


### PR DESCRIPTION
## Summary
- treat `error` from `useAccountData` as a string

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854a2092ed4832bafe9b63fd82e3cc7