### PR TITLE
Handle schema errors in account data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "@tailwindcss/vite": "^4.1.10",
+        "@types/debug": "^4.1.12",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.2",
@@ -2024,6 +2025,16 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -2036,6 +2047,13 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.15.29",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@eslint/js": "^9.29.0",
     "@tailwindcss/vite": "^4.1.10",
+    "@types/debug": "^4.1.12",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",

--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,20 +1,56 @@
 import { useExists, useJson } from '@artifact/client/hooks'
 import { accountDataSchema, type AccountData } from '../types/account.ts'
 import { useEffect, useState } from 'react'
+import useAccountSaver from './useAccountSaver.ts'
+import Debug from 'debug'
+
+const log = Debug('frame-account-panel:useAccountData')
+
+const emptyUsage = {
+  period: '',
+  storage: { gained: 0, lost: 0, gainedCost: 0, lostRefund: 0 },
+  compute: 0,
+  computeCost: 0,
+  bandwidth: 0,
+  bandwidthCost: 0,
+  aiTokens: 0,
+  aiTokensCost: 0
+}
+
+const defaultAccount: AccountData = {
+  user: { name: '', email: '', profilePicture: '' },
+  paymentMethods: [],
+  billing: { balance: 0, currency: 'USD', usageHistory: [emptyUsage] }
+}
 
 const useAccountData = () => {
   const exists = useExists('profile.json')
   const raw = useJson('profile.json')
   const [data, setData] = useState<AccountData>()
+  const saveAccount = useAccountSaver()
 
   useEffect(() => {
     if (raw !== undefined) {
-      setData(accountDataSchema.parse(raw))
+      try {
+        setData(accountDataSchema.parse(raw))
+      } catch (e) {
+        log('Failed to parse %s: %o', 'profile.json', e)
+        setData(defaultAccount)
+        saveAccount(defaultAccount).catch((err) =>
+          log('Failed to write %s: %o', 'profile.json', err)
+        )
+      }
     }
-  }, [raw])
+  }, [raw, saveAccount])
 
   const loading = exists === null || (exists && raw === undefined)
   const error = exists === false ? 'profile.json not found' : null
+
+  useEffect(() => {
+    if (exists === false) {
+      log('File not found: %s', 'profile.json')
+    }
+  }, [exists])
 
   return { data, loading, error }
 }


### PR DESCRIPTION
## Summary
- handle parsing errors for `profile.json`
- create default account data when parser fails
- log missing or unparsable files via the debug logger
- add `@types/debug` dependency

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854ac834538832ba2e696e8731df0aa