### PR TITLE
Handle missing profiles without saving

### DIFF
--- a/src/AccountView.tsx
+++ b/src/AccountView.tsx
@@ -7,7 +7,6 @@ import {
   BillingSection,
   SecuritySection
 } from './components/index.ts'
-import InitializingModal from './components/modals/InitializingModal.tsx'
 import DeleteAccountModal from './components/modals/DeleteAccountModal.tsx'
 import TopUpModal from './components/modals/TopUpModal.tsx'
 import useAccountData from './hooks/useAccountData.ts'
@@ -59,8 +58,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
   const [showTopUpModal, setShowTopUpModal] = useState(false)
   const [topUpAmount, setTopUpAmount] = useState('10')
   const [customAmount, setCustomAmount] = useState('')
-  const [initializing, setInitializing] = useState(false)
-  const [initialized, setInitialized] = useState(false)
 
   useEffect(() => {
     if (data) {
@@ -69,19 +66,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
       setBillingData(data.billing)
     }
   }, [data])
-
-  useEffect(() => {
-    if (!initialized && error === 'profile.json not found') {
-      setInitializing(true)
-      setInitialized(true)
-      const defaultAccount = {
-        user: { name: '', email: '', profilePicture: '' },
-        paymentMethods: [] as PaymentMethod[],
-        billing: { balance: 0, currency: 'USD', usageHistory: [emptyUsage] }
-      }
-      saveAccount(defaultAccount).finally(() => setInitializing(false))
-    }
-  }, [error, initialized, saveAccount])
 
   const showDeleteAccountConfirm = () => {
     setShowDeleteConfirm(true)
@@ -221,7 +205,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
       {!isSkeleton && (
         <>
           {/* Modals */}
-          <InitializingModal show={initializing} />
           <DeleteAccountModal
             showDeleteConfirm={showDeleteConfirm}
             dismissDeleteConfirm={dismissDeleteConfirm}

--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,7 +1,7 @@
 import { useExists, useJson } from '@artifact/client/hooks'
 import { accountDataSchema, type AccountData } from '../types/account.ts'
 import { useEffect, useState } from 'react'
-import useAccountSaver from './useAccountSaver.ts'
+
 import Debug from 'debug'
 
 const log = Debug('frame-account-panel:useAccountData')
@@ -27,7 +27,6 @@ const useAccountData = () => {
   const exists = useExists('profile.json')
   const raw = useJson('profile.json')
   const [data, setData] = useState<AccountData>()
-  const saveAccount = useAccountSaver()
 
   useEffect(() => {
     if (raw !== undefined) {
@@ -36,12 +35,9 @@ const useAccountData = () => {
       } catch (e) {
         log('Failed to parse %s: %o', 'profile.json', e)
         setData(defaultAccount)
-        saveAccount(defaultAccount).catch((err) =>
-          log('Failed to write %s: %o', 'profile.json', err)
-        )
       }
     }
-  }, [raw, saveAccount])
+  }, [raw])
 
   const loading = exists === null || (exists && raw === undefined)
   const error = exists === false ? 'profile.json not found' : null
@@ -49,6 +45,7 @@ const useAccountData = () => {
   useEffect(() => {
     if (exists === false) {
       log('File not found: %s', 'profile.json')
+      setData(defaultAccount)
     }
   }, [exists])
 

--- a/src/hooks/useAccountSaver.ts
+++ b/src/hooks/useAccountSaver.ts
@@ -1,12 +1,30 @@
 import { useArtifact } from '@artifact/client/hooks'
 import type { AccountData } from '../types/account.ts'
 
+const emptyUsage = {
+  period: '',
+  storage: { gained: 0, lost: 0, gainedCost: 0, lostRefund: 0 },
+  compute: 0,
+  computeCost: 0,
+  bandwidth: 0,
+  bandwidthCost: 0,
+  aiTokens: 0,
+  aiTokensCost: 0
+}
+
+const defaultAccount: AccountData = {
+  user: { name: '', email: '', profilePicture: '' },
+  paymentMethods: [],
+  billing: { balance: 0, currency: 'USD', usageHistory: [emptyUsage] }
+}
+
 const useAccountSaver = () => {
   const artifact = useArtifact()
 
-  return async (data: AccountData): Promise<void> => {
+  return async (data?: AccountData): Promise<void> => {
     if (!artifact) return
-    artifact.files.write.json('profile.json', data)
+    const toWrite = data ?? defaultAccount
+    artifact.files.write.json('profile.json', toWrite)
     await artifact.branch.write.commit('Update account data')
   }
 }


### PR DESCRIPTION
## Summary
- return defaults from `useAccountData` when the file is missing
- remove automatic initialization logic from `AccountView`
- default to a blank profile in `useAccountSaver`

## Testing
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_6854d0a8ef08832bbc131f7c2eeb84bc