### PR TITLE
Fix profile initialization overwrite

### DIFF
--- a/src/AccountView.tsx
+++ b/src/AccountView.tsx
@@ -7,7 +7,6 @@ import {
   BillingSection,
   SecuritySection
 } from './components/index.ts'
-import InitializingModal from './components/modals/InitializingModal.tsx'
 import DeleteAccountModal from './components/modals/DeleteAccountModal.tsx'
 import TopUpModal from './components/modals/TopUpModal.tsx'
 import useAccountData from './hooks/useAccountData.ts'
@@ -59,8 +58,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
   const [showTopUpModal, setShowTopUpModal] = useState(false)
   const [topUpAmount, setTopUpAmount] = useState('10')
   const [customAmount, setCustomAmount] = useState('')
-  const [initializing, setInitializing] = useState(false)
-  const [initialized, setInitialized] = useState(false)
 
   useEffect(() => {
     if (data) {
@@ -69,19 +66,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
       setBillingData(data.billing)
     }
   }, [data])
-
-  useEffect(() => {
-    if (!initialized && error === 'profile.json not found') {
-      setInitializing(true)
-      setInitialized(true)
-      const defaultAccount = {
-        user: { name: '', email: '', profilePicture: '' },
-        paymentMethods: [] as PaymentMethod[],
-        billing: { balance: 0, currency: 'USD', usageHistory: [emptyUsage] }
-      }
-      saveAccount(defaultAccount).finally(() => setInitializing(false))
-    }
-  }, [error, initialized, saveAccount])
 
   const showDeleteAccountConfirm = () => {
     setShowDeleteConfirm(true)
@@ -221,7 +205,6 @@ const AccountView: React.FC<AccountViewProps> = ({ skeleton }) => {
       {!isSkeleton && (
         <>
           {/* Modals */}
-          <InitializingModal show={initializing} />
           <DeleteAccountModal
             showDeleteConfirm={showDeleteConfirm}
             dismissDeleteConfirm={dismissDeleteConfirm}

--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,7 +1,6 @@
 import { useExists, useJson } from '@artifact/client/hooks'
 import { accountDataSchema, type AccountData } from '../types/account.ts'
 import { useEffect, useState } from 'react'
-import useAccountSaver from './useAccountSaver.ts'
 import Debug from 'debug'
 
 const log = Debug('frame-account-panel:useAccountData')
@@ -27,30 +26,23 @@ const useAccountData = () => {
   const exists = useExists('profile.json')
   const raw = useJson('profile.json')
   const [data, setData] = useState<AccountData>()
-  const saveAccount = useAccountSaver()
 
   useEffect(() => {
-    if (raw !== undefined) {
+    if (exists === false) {
+      log('File not found: %s', 'profile.json')
+      setData(defaultAccount)
+    } else if (raw !== undefined) {
       try {
         setData(accountDataSchema.parse(raw))
       } catch (e) {
         log('Failed to parse %s: %o', 'profile.json', e)
         setData(defaultAccount)
-        saveAccount(defaultAccount).catch((err) =>
-          log('Failed to write %s: %o', 'profile.json', err)
-        )
       }
     }
-  }, [raw, saveAccount])
+  }, [exists, raw])
 
   const loading = exists === null || (exists && raw === undefined)
   const error = exists === false ? 'profile.json not found' : null
-
-  useEffect(() => {
-    if (exists === false) {
-      log('File not found: %s', 'profile.json')
-    }
-  }, [exists])
 
   return { data, loading, error }
 }


### PR DESCRIPTION
## Summary
- do not automatically write a new profile when parsing fails
- avoid pre-emptive save when the file is missing

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854d0a8ef08832bbc131f7c2eeb84bc